### PR TITLE
CLI: Resolve filename

### DIFF
--- a/cmd/args.go
+++ b/cmd/args.go
@@ -13,8 +13,8 @@ var ArgsCmd = &cobra.Command{
 	Short: "Print the SSH command for a host",
 	Long:  "Print the SSH command for a host",
 	Run: func(cmd *cobra.Command, args []string) {
-		// Get config filename from flags.
-		filename, _ := cmd.Flags().GetString("filename")
+		// Resolve filename from flags.
+		filename := resolveFilename(cmd)
 
 		// Check that only one host was specified.
 		if len(args) != 1 {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -29,7 +29,7 @@ var RootCmd = &cobra.Command{
 func init() {
 	// Create flags for RootCmd.
 	RootCmd.Flags().BoolVarP(&version, "version", "v", false, "View version information")
-	RootCmd.PersistentFlags().StringVarP(&config, "filename", "f", getDefaultConfig(), "Specify config file")
+	RootCmd.PersistentFlags().StringVarP(&config, "filename", "f", "", "Specify config file")
 }
 
 // AddCommands - Connects subcommands to the RootCmd.

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -13,8 +13,8 @@ var ConnectCmd = &cobra.Command{
 	Short: "Connect to a host",
 	Long:  "Connect to a host",
 	Run: func(cmd *cobra.Command, args []string) {
-		// Get config filename from flags.
-		filename, _ := cmd.Flags().GetString("filename")
+		// Resolve filename from flags.
+		filename := resolveFilename(cmd)
 
 		// Check that only one host was specified.
 		if len(args) != 1 {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -11,8 +11,8 @@ var ListCmd = &cobra.Command{
 	Short: "List all hosts",
 	Long:  "List all hosts",
 	Run: func(cmd *cobra.Command, args []string) {
-		// Get config filename from flags.
-		filename, _ := cmd.Flags().GetString("filename")
+		// Resolve filename from flags.
+		filename := resolveFilename(cmd)
 
 		// List all hosts.
 		engine.Init(filename).List()

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -13,8 +13,8 @@ var StatusCmd = &cobra.Command{
 	Short: "Check the status of one or more hosts",
 	Long:  "Check the status of one or more hosts",
 	Run: func(cmd *cobra.Command, args []string) {
-		// Get config filename from flags.
-		filename, _ := cmd.Flags().GetString("filename")
+		// Resolve filename from flags.
+		filename := resolveFilename(cmd)
 
 		// Check that only one host was specified.
 		if len(args) == 0 {

--- a/cmd/utils_.go
+++ b/cmd/utils_.go
@@ -1,5 +1,14 @@
 package cmd
 
+import (
+	"errors"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
 func getDefaultConfig() string {
 	return "./konnect.yml"
 }
@@ -21,4 +30,36 @@ func removeDuplicates(elements []string) []string {
 		}
 	}
 	return result
+}
+
+// Resolve the config filename from cmd flags.
+// Fallback to default filename.
+// Validate that the file exists.
+func resolveFilename(cmd *cobra.Command) string {
+	// Get config filename from flags.
+	filename, _ := cmd.Flags().GetString("filename")
+	wasProvided := true
+
+	// If filename is not specified, then set
+	// to default config filename.
+	if filename == "" {
+		wasProvided = false
+		filename = getDefaultConfig()
+	}
+
+	// Check if the filename exists.
+	if _, err := os.Stat(filename); err != nil {
+		// Could not find a config file.
+		if wasProvided == false {
+			err = errors.New("Could not find a " +
+				"konnect.yml configuration file " +
+				"in this directory")
+		} else {
+			// Could not find the config file that the user specified.
+			err = fmt.Errorf("Config %v does not exist", filename)
+		}
+		log.Fatal(err)
+	}
+
+	return filename
 }


### PR DESCRIPTION
### Summary
Create functionality to resolve and validate config filenames.

`func resolveFilename(cmd *cobra.Command) string`:
- Resolve the config filename from cmd flags.
- Fallback to default filename.
- Validate that the file exists.