### PR TITLE
Task-10: Sort Host names

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -46,7 +46,7 @@ var StatusCmd = &cobra.Command{
 		konnect.CheckHosts(hosts)
 
 		// Check status of the resolved hosts.
-		fmt.Printf("Testing connections for %v\n", strings.Join(hosts, ", "))
+		fmt.Printf("Testing connections for %v\n\n", strings.Join(hosts, ", "))
 		konnect.Status(hosts)
 	},
 }

--- a/engine/api.go
+++ b/engine/api.go
@@ -24,8 +24,9 @@ func Init(filename string) *Konnect {
 
 // List - Show info for all SSHProxy objects.
 func (k *Konnect) List() {
-	for _, proxy := range k.Hosts {
-		fmt.Println(proxy.Info())
+	hosts := k.GetHosts()
+	for _, host := range hosts {
+		fmt.Println(k.Hosts[host].Info())
 	}
 }
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"sort"
 
 	yaml "gopkg.in/yaml.v2"
 
@@ -29,12 +30,13 @@ func (k *Konnect) Get(name string) (*proxy.SSHProxy, error) {
 	return proxy, nil
 }
 
-// GetHosts - Get host names.
+// GetHosts - Get host names in sorted order (asc).
 func (k *Konnect) GetHosts() []string {
 	names := []string{}
 	for host := range k.Hosts {
 		names = append(names, host)
 	}
+	sort.Strings(names)
 	return names
 }
 


### PR DESCRIPTION
### Summary
For `konnect.GetHosts`, return host names in sorted (asc) order.
