### PR TITLE
Global configs in konnect.yml

### DIFF
--- a/proxy/sshproxy.go
+++ b/proxy/sshproxy.go
@@ -123,23 +123,23 @@ func (s *SSHProxy) Validate() error {
 	return nil
 }
 
-// UnmarshalYAML - Populate an SSHProxy struct from a yaml byte string.
-// https://goo.gl/yvLJkj
-func (s *SSHProxy) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	// Create an alias type.
-	type SSHAlias SSHProxy
-
-	// Convert new value to the alias type.
-	var temp = (*SSHAlias)(Default())
-
-	// Unmarshal into the aliased type.
-	if err := unmarshal(temp); err != nil {
-		return err
+// PopulateFromProxy - Fill in values from a global proxy object.
+func (s *SSHProxy) PopulateFromProxy(global *SSHProxy) {
+	if s.User == "" {
+		s.User = global.User
 	}
 
-	// Case the alias back to the original type.
-	*s = SSHProxy(*temp)
-	return nil
+	if s.Host == "" {
+		s.Host = global.Host
+	}
+
+	if s.Port == 0 {
+		s.Port = global.Port
+	}
+
+	if s.Key == "" {
+		s.Key = global.Key
+	}
 }
 
 // TestConnection - Test SSHProxy connection.

--- a/proxy/utils_.go
+++ b/proxy/utils_.go
@@ -32,12 +32,18 @@ func New(user, host string, port int, key string) *SSHProxy {
 	}
 }
 
-// Default - Create a new SSHProxy object with default values.
-func Default() *SSHProxy {
+// NewGlobal - Create a new SSHProxy object
+// that will be used as a global config.
+func NewGlobal() *SSHProxy {
 	return &SSHProxy{
 		User: "",
 		Host: "",
 		Port: getDefaultPort(),
 		Key:  getDefaultKey(),
 	}
+}
+
+// Default test.
+func Default() *SSHProxy {
+	return &SSHProxy{}
 }


### PR DESCRIPTION
### Summary
- Create global proxy config in Konnect struct.
- Add functionality for unmarshalling global proxy config.
- Move SSHProxy unmarshalling to Konnect struct. Fill in blank SSHProxy fields with global fields.

---


**[config without global]**
```
hosts:
  app:
    user: admin
    host: 127.0.0.1
    port: 22
    key: /home/app/key
  database:
    user: admin
    host: 192.168.99.100
    port: 89
    key: ~/.ssh/id_rsa
```

---

**[config with global]**

```
global:
  user: admin

hosts:
  app:
    host: 127.0.0.1
    port: 22
    key: /home/app/key
  database:
    host: 192.168.99.100
    port: 89
    key: ~/.ssh/id_rsa
```


---

**[alternative host string]**

```
global:
  user: admin
  port: 23
  key: /home/app/key

hosts:
  app: 127.0.0.1
  database:
    host: 192.168.99.100
    port: 89
    key: ~/.ssh/id_rsa
```
