### PR TITLE
Task-41: Command to open config file.

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -105,6 +105,7 @@ func AddCommands() {
 	RootCmd.AddCommand(ConnectCmd)
 	RootCmd.AddCommand(InitCmd)
 	RootCmd.AddCommand(ListCmd)
+	RootCmd.AddCommand(OpenCmd)
 	RootCmd.AddCommand(StatusCmd)
 	RootCmd.AddCommand(VersionCmd)
 }

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+)
+
+// OpenCmd - Open the konnect.yml config file with the default editor.
+var OpenCmd = &cobra.Command{
+	Use:   "open",
+	Short: "Open the config file with the default editor",
+	Long:  "Open the config file with the default editor",
+	Run: func(cmd *cobra.Command, args []string) {
+		// Resolve filename from flags.
+		filename, err := resolveFilename(cmd)
+		handleErr(err)
+
+		fmt.Printf("Opening config file. (%v)\n", filename)
+
+		if err := exec.Command("open", filename).Run(); err != nil {
+			log.Fatal("Error when opening the config file.")
+		}
+	},
+}


### PR DESCRIPTION
### Summary
Add an `open` command to open the config file with the default OS editor.
