### PR TITLE
Task-36: Connect up the filesystem

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -32,7 +32,7 @@ var InitCmd = &cobra.Command{
 		dir, _ = filepath.Abs(dir)
 
 		// Get the default name for the config file.
-		localFilename := getDefaultConfig()
+		localFilename := getDefaultConfigs()[0]
 
 		// Join the resolved directory with
 		// the default config filename.


### PR DESCRIPTION
### Summary
Modify the `resolveFilename` function to fallback to default config filenames.

If a config filename is not specified, it falls back to one of two options:
- a `konnect.yml` file in the current directory.
- a `konnect.yml` file in the parent directory.
