### PR TITLE
Changes on interactive prompt

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -2,11 +2,8 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"os"
 
-	"github.com/AlecAivazis/survey"
-	"github.com/exitshell/konnect/engine"
 	"github.com/spf13/cobra"
 )
 
@@ -29,16 +26,18 @@ var RootCmd = &cobra.Command{
 	Short: "Connect to SSH hosts.",
 	Long:  "Konnect is a tool to define and connect to SSH hosts.",
 	Run: func(cmd *cobra.Command, args []string) {
-		cmd.Help()
+		// Perform interactive connect prompt.
+		if err := interactivePrompt(cmd); err != nil {
+			if err == errConfigNotFound {
+				cmd.Help()
+				fmt.Println()
+			}
+			handleErr(err)
+		}
 	},
 	PreRun: func(cmd *cobra.Command, args []string) {
 		if version {
 			fmt.Println(AppVersion)
-			os.Exit(0)
-		}
-
-		if interactive {
-			InteractivePrompt(cmd)
 			os.Exit(0)
 		}
 	},
@@ -47,56 +46,8 @@ var RootCmd = &cobra.Command{
 func init() {
 	// Config filename.
 	RootCmd.PersistentFlags().StringVarP(&config, "filename", "f", "", "Specify config file")
-	// Show an iteractive prompt to connect to hosts.
-	RootCmd.Flags().BoolVarP(&interactive, "interactive", "i", false, "Connect to a host interactively")
 	// Show version information.
 	RootCmd.Flags().BoolVarP(&version, "version", "v", false, "View version information")
-}
-
-// InteractivePrompt to connect to hosts.
-func InteractivePrompt(cmd *cobra.Command) {
-	fmt.Println("Starting interactive prompt...")
-	// Resolve filename from flags.
-	filename, err := resolveFilename(cmd)
-	handleErr(err)
-
-	// Init engine.
-	konnect, err := engine.Init(filename)
-	handleErr(err)
-
-	// Get host names.
-	hosts := konnect.GetHostNames()
-
-	// Create survey.
-	prompt := []*survey.Question{
-		{
-			Name:     "Hostname",
-			Validate: survey.Required,
-			Prompt: &survey.Select{
-				Message: "Connect to host:",
-				Options: hosts,
-			},
-		},
-	}
-
-	// Create answer.
-	answer := struct {
-		Hostname string
-	}{}
-
-	// Show prompt.
-	if err = survey.Ask(prompt, &answer); err != nil {
-		log.Fatal("No host was selected")
-	}
-
-	// Get proxy.
-	proxy, err := konnect.GetHost(answer.Hostname)
-	handleErr(err)
-
-	// Connect to host.
-	if err := proxy.Connect(); err != nil {
-		log.Fatal(err)
-	}
 }
 
 // AddCommands - Connects subcommands to the RootCmd.

--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -1,0 +1,6 @@
+package cmd
+
+import "errors"
+
+var errConfigNotFound = errors.New("could not find a konnect.yml configuration file")
+var errNoHostSelected = errors.New("no host was selected")

--- a/cmd/interactive_.go
+++ b/cmd/interactive_.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/AlecAivazis/survey"
+	"github.com/exitshell/konnect/engine"
+	"github.com/spf13/cobra"
+)
+
+// An interactivePrompt to connect to hosts.
+func interactivePrompt(cmd *cobra.Command) error {
+	// Resolve filename from flags.
+	filename, err := resolveFilename(cmd)
+	if err != nil {
+		return err
+	}
+	fmt.Println(filename)
+
+	// Init engine.
+	konnect, err := engine.Init(filename)
+	if err != nil {
+		return err
+	}
+
+	// Get host names.
+	hosts := konnect.GetHostNames()
+
+	// Create survey.
+	prompt := []*survey.Question{
+		{
+			Name:     "Hostname",
+			Validate: survey.Required,
+			Prompt: &survey.Select{
+				Message: "Connect to host:",
+				Options: hosts,
+			},
+		},
+	}
+
+	// Create answer.
+	answer := struct {
+		Hostname string
+	}{}
+
+	// Show prompt.
+	if err = survey.Ask(prompt, &answer); err != nil {
+		return errNoHostSelected
+	}
+
+	// Get proxy.
+	proxy, err := konnect.GetHost(answer.Hostname)
+	if err != nil {
+		return err
+	}
+
+	// Connect to host.
+	return proxy.Connect()
+}

--- a/cmd/utils_.go
+++ b/cmd/utils_.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -71,9 +70,7 @@ func resolveFilename(cmd *cobra.Command) (string, error) {
 
 	// At this point, none of the possible filenames
 	// were found. Return an error.
-	err := errors.New("Could not find a " +
-		"konnect.yml configuration file.")
-	return "", err
+	return "", errConfigNotFound
 }
 
 func makeDefaultConfig(filename string) error {


### PR DESCRIPTION
### Summary
Changes on interactive prompt:
- Make remove `-i` flag and make interactive prompt the default action for the konnect root command. If config file is not found, then print the Help and exit.
- Make custom errors for the `cmd` package.